### PR TITLE
chore: update axum and tokio to latest compatible versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7.5"
 shuttle-axum = "0.36.0"
 shuttle-runtime = "0.36.0"
-tokio = { version = "1.35.1", features = ["full"] }
+tokio = { version = "1.40.0", features = ["full"] }


### PR DESCRIPTION
```text
$ cargo upgrade
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking probable-octo-lamp's dependencies
name  old req compatible latest new req
====  ======= ========== ====== =======
axum  0.7.4   0.7.5      0.7.5  0.7.5
tokio 1.35.1  1.40.0     1.40.0 1.40.0
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 44 unchanged dependencies behind latest
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: shuttle-axum, shuttle-runtime
```